### PR TITLE
use Fetch

### DIFF
--- a/src/site.ts
+++ b/src/site.ts
@@ -43,7 +43,7 @@ async function getInput(year: number, day: number, forceRefresh = false) {
         inputs = input.split('\n');
         while (inputs.at(-1) === '') inputs.pop();
     } catch (err) {
-        const { body: input } = await request('GET', `/${year}/day/${day}/input`, process.env.AOC_SESSION_COOKIE, process.env.CERTIFICATE);
+        const input = await request('GET', `/${year}/day/${day}/input`, process.env.AOC_SESSION_COOKIE!, process.env.CERTIFICATE);
         if (input === 'Puzzle inputs differ by user.  Please log in to get your puzzle input.\n') throw new Error(errExpiredSessionCookie);
         inputs = input.split('\n');
         while (inputs.at(-1) === '') inputs.pop();
@@ -89,7 +89,7 @@ async function getLeaderboard(year: number, id: string, refreshIfPossible = fals
         if (refreshIfPossible && isPossible) throw new Error('Force refresh');
         json = await read(`${year}/${id}.json`);
     } catch (err) {
-        const { body: json } = await request('GET', `${year}/leaderboard/private/view/${id}.json`, process.env.AOC_SESSION_COOKIE, process.env.CERTIFICATE);
+        const json = await request('GET', `${year}/leaderboard/private/view/${id}.json`, process.env.AOC_SESSION_COOKIE!, process.env.CERTIFICATE);
         await write(`${year}/${id}.json`, json);
         await write(`lastLeaderboardRequest.json`, Date.now().toString());
     }
@@ -103,7 +103,7 @@ async function getPuzzle(year: number, day: number, forceRefresh = false) {
         if (forceRefresh) throw new Error('Force refresh');
         puzzle = await read(`${year}/puzzles/${day}.html`);
     } catch (err) {
-        ({ body: puzzle } = await request('GET', `/${year}/day/${day}`, process.env.AOC_SESSION_COOKIE, process.env.CERTIFICATE));
+        puzzle = await request('GET', `/${year}/day/${day}`, process.env.AOC_SESSION_COOKIE!, process.env.CERTIFICATE);
         const $ = load(puzzle);
         const login = $(`a[href="/${year}/auth/login"]`);
         if (login.length > 0) throw new Error(errExpiredSessionCookie);
@@ -120,7 +120,7 @@ async function getPuzzle(year: number, day: number, forceRefresh = false) {
         }
     })();
     if (cachev != sitev) { // Get CSS if it doesn't exist or is an older version
-        const { body: css } = await request('GET', `/static/style.css?${sitev}`, process.env.AOC_SESSION_COOKIE, process.env.CERTIFICATE);
+        const css = await request('GET', `/static/style.css?${sitev}`, process.env.AOC_SESSION_COOKIE!, process.env.CERTIFICATE);
         await write(`static/style.css`, css);
         await write(`static/version`, sitev);
     }
@@ -249,7 +249,7 @@ async function submitAnswer(year: number, day: number, part: number, answer: num
         level: part,
         answer: answerStr
     });
-    let { headers, body: response } = await request('POST', path, process.env.AOC_SESSION_COOKIE, process.env.CERTIFICATE, formData);
+    let response = await request('POST', path, process.env.AOC_SESSION_COOKIE!, process.env.CERTIFICATE, formData);
     let timestamp = new Date().toJSON();
     await write(`${year}/lastPOSTResponse.html`, response);
     let $ = load(response);
@@ -265,7 +265,7 @@ async function submitAnswer(year: number, day: number, part: number, answer: num
             const [s, m = 0, h = 0, d = 0] = match.reverse().map(e => parseInt(e)); // Does it ever go beyond minutes?  Who knows!
             await countdown(new Date(Date.now() + (s + m * 60 + h * 60 * 60 + d * 24 * 60 * 60) * 1000));
             // Resubmit
-            ({ headers, body: response } = await request('POST', path, process.env.AOC_SESSION_COOKIE, process.env.CERTIFICATE, formData));
+            response = await request('POST', path, process.env.AOC_SESSION_COOKIE!, process.env.CERTIFICATE, formData);
             timestamp = new Date().toJSON();
             $ = load(response);
         } else {


### PR DESCRIPTION
`[fetch()](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch)` is the "standard" http client on Node and Web JS. Switching to it simplifies the code a bit, unfortunately you can't do the same cert chain, so I kept that method.

Other changes:
* the session cookie is validated beforehand, so make it required
* the headers returned were never used, so instead just return the body as a string