### PR TITLE
Session cookie

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -40,6 +40,9 @@ A session cookie is required in order to log in to the adventofcode.com site.
 ` + cookieSteps);
         return false;
     }
+    if (!process.env.AOC_SESSION_COOKIE.startsWith('session=')) {
+        process.env.AOC_SESSION_COOKIE = 'session=' + process.env.AOC_SESSION_COOKIE;
+    }
     return true;
 }
 


### PR DESCRIPTION
Just a small addition. Other AoC helpers usually only require the value of the cookie, and when I first started using aoc-copilot I didn't put the `session=` at the beginning, and the error was my cookie was expired, which is incorrect and I spent a while trying to figure it out.